### PR TITLE
Add support for numerics 001-004

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -94,9 +94,10 @@ impl<'a> Command<'a> for Privmsg<'a> {
 
 // Simple numerics are the numerics which have nothing but a single associated message. For
 // these, we avail ourselves of a macro to define a suitable command implementation.
-
 macro_rules! simple_numeric {
-    ($num:expr, $numeric_name:ident) => (
+    // Hackyness to allow doc-comments; it looks kinda icky, but it works!
+    ($(#[$meta:meta])* ($num:expr, $numeric_name:ident)) => (
+        $(#[$meta])*
         pub struct $numeric_name<'a>(pub &'a str);
 
         impl<'a> Command<'a> for $numeric_name<'a> {
@@ -111,10 +112,22 @@ macro_rules! simple_numeric {
     )
 }
 
-simple_numeric!("001", Welcome);
-simple_numeric!("002", YourHost);
-simple_numeric!("003", Created);
-simple_numeric!("004", ServerInfo);
+simple_numeric!{
+  /// Represents a WELCOME numeric. The welcome message is the only element.
+  ("001", Welcome)
+}
+simple_numeric!{
+  /// Represents a YOURHOST numeric. The yourhost message is the only element.
+  ("002", YourHost)
+}
+simple_numeric!{
+  /// Represents a CREATED numeric. The created message is the only element.
+  ("003", Created)
+}
+simple_numeric!{
+  /// Represents a MYINFO numeric. The server info message is the only element.
+  ("004", ServerInfo)
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/command.rs
+++ b/src/command.rs
@@ -92,6 +92,30 @@ impl<'a> Command<'a> for Privmsg<'a> {
     }
 }
 
+// Simple numerics are the numerics which have nothing but a single associated message. For
+// these, we avail ourselves of a macro to define a suitable command implementation.
+
+macro_rules! simple_numeric {
+    ($num:expr, $numeric_name:ident) => (
+        pub struct $numeric_name<'a>(pub &'a str);
+
+        impl<'a> Command<'a> for $numeric_name<'a> {
+            fn name() -> &'static str {
+                $num
+            }
+
+            fn parse(arguments: ArgumentIter<'a>) -> Option<$numeric_name<'a>> {
+                arguments.skip(1).next().map(|x| $numeric_name(x))
+            }
+        }
+    )
+}
+
+simple_numeric!("001", Welcome);
+simple_numeric!("002", YourHost);
+simple_numeric!("003", Created);
+simple_numeric!("004", ServerInfo);
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -120,5 +144,13 @@ mod tests {
 
         assert_eq!("#channel", target);
         assert_eq!("This is a message!", message);
+    }
+
+    #[test]
+    fn test_welcome_numerc() {
+        let msg = welcome("robots", "our overlords").unwrap();
+        let Welcome(body) = msg.command::<Welcome>().unwrap();
+
+        assert_eq!("our overlords", body);
     }
 }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -12,7 +12,7 @@ use tag::{Tag, TagIter};
 
 use std::ops::Range;
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 struct PrefixRange {
     raw_prefix: Range<usize>,
     prefix: Range<usize>,
@@ -24,7 +24,7 @@ type TagRange = (Range<usize>, Option<Range<usize>>);
 
 /// Representation of IRC messages that splits a message into its constituent
 /// parts specified in RFC1459 and the IRCv3 spec.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Message {
     message: String,
     tags: Option<Vec<TagRange>>,
@@ -143,4 +143,24 @@ pub fn join<C: Into<String>>(channel: C) -> Result<Message> {
 /// Constructs a message containing a PRIVMSG command sent to the specified targets with the given message.
 pub fn privmsg<T: Into<String>, M: Into<String>>(targets: T, message: M) -> Result<Message> {
     Message::try_from(format!("PRIVMSG {} :{}", targets.into(), message.into()))
+}
+
+/// Constructs a message containing a WELCOME numeric with the specified contents.
+pub fn welcome<T: Into<String>>(target: T, message: T) -> Result<Message> {
+    Message::try_from(format!("001 {} :{}", target.into(), message.into()))
+}
+
+/// Constructs a message containing a YOURHOST numeric with the specified contents.
+pub fn yourhost<T: Into<String>>(target: T, message: T) -> Result<Message> {
+    Message::try_from(format!("002 {} :{}", target.into(), message.into()))
+}
+
+/// Constructs a message containing a CREATED numeric with the specified contents.
+pub fn created<T: Into<String>>(target: T, message: T) -> Result<Message> {
+    Message::try_from(format!("003 {} :{}", target.into(), message.into()))
+}
+
+/// Constructs a message containing a MYINFO numeric with the specified contents.
+pub fn serverinfo<T: Into<String>>(target: T, message: T) -> Result<Message> {
+    Message::try_from(format!("004 {} :{}", target.into(), message.into()))
 }

--- a/src/message/parser.rs
+++ b/src/message/parser.rs
@@ -332,11 +332,20 @@ mod tests {
     }
 
     #[test]
-    fn parse_command_with_preefix_and_host() {
+    fn parse_command_with_prefix_and_host() {
         let result = parse_message(":foo@host.test.com TEST").unwrap();
 
         let prefix = result.prefix();
 
         assert_eq!(Some(("foo", None, Some("host.test.com"))), prefix);
+    }
+
+    #[test]
+    fn parse_numeric_welcome() {
+        let result = parse_message("001 fjtest :Welcome to the Meme Loving IRC Network same@me.irl").unwrap();
+
+        assert_eq!("001", result.raw_command());
+        assert_eq!(vec!["fjtest", "Welcome to the Meme Loving IRC Network same@me.irl"], 
+                   result.raw_args().collect::<Vec<&str>>());
     }
 }


### PR DESCRIPTION
These numerics are useful for identifying when the server acknowledges
your connection so that further messages, such as 'join', can be sent.

Note that I'm intentionally throwing away the "clientname" portion at the beginning of these numerics because it is, as far as I know, useless.

See the ever useful http://modern.ircdocs.horse/#numerics